### PR TITLE
[vault] More fine-grained control of GCE PD labels

### DIFF
--- a/modules/vault/README.md
+++ b/modules/vault/README.md
@@ -180,6 +180,7 @@ unsealing Vault if the nodes have access to the keys.
 |------|---------|
 | terraform | >= 0.12.17 |
 | helm | >= 1.0 |
+| kubernetes | >= 1.11.4 |
 
 ## Providers
 
@@ -187,7 +188,7 @@ unsealing Vault if the nodes have access to the keys.
 |------|---------|
 | google-beta | n/a |
 | helm | >= 1.0 |
-| kubernetes | n/a |
+| kubernetes | >= 1.11.4 |
 | local | n/a |
 
 ## Inputs
@@ -249,8 +250,10 @@ unsealing Vault if the nodes have access to the keys.
 | project\_id | Project ID for GCP Resources | `any` | n/a | yes |
 | raft\_backup\_max\_retention\_days | Maximum daily age of the snapshot that is allowed to be kept. | `number` | `14` | no |
 | raft\_backup\_policy | Data disk backup policy name | `string` | `"vault-data-backup"` | no |
+| raft\_disk\_labels | Override labels for Raft GCE PD resources. Will use `var.labels` if set to null | `map(string)` | `null` | no |
 | raft\_disk\_regional | Use regional disks instead of zonal disks | `bool` | `true` | no |
 | raft\_disk\_size | Size of Raft disks in GB | `number` | `10` | no |
+| raft\_disk\_snapshot\_labels | Override labels for Raft GCE PD snapshot resources. Will use `var.labels` if set to null | `map(string)` | `null` | no |
 | raft\_disk\_type | Raft data disk type | `string` | `"pd-ssd"` | no |
 | raft\_disk\_zones | List of zones for disks. If not set, will default to the zones in var.region | `list(string)` | `[]` | no |
 | raft\_extra\_parameters | Extra parameters for Raft storage | `map` | `{}` | no |

--- a/modules/vault/storage_raft.tf
+++ b/modules/vault/storage_raft.tf
@@ -10,7 +10,7 @@ resource "google_compute_disk" "raft" {
 
   description = "Vault server data disks replica ${count.index}"
 
-  labels  = var.labels
+  labels  = coalesce(var.raft_disk_labels, var.labels)
   project = var.project_id
 
   disk_encryption_key {
@@ -38,7 +38,7 @@ resource "google_compute_region_disk" "raft" {
 
   description = "Vault server data disks replica ${count.index}"
 
-  labels  = var.labels
+  labels  = coalesce(var.raft_disk_labels, var.labels)
   project = var.project_id
 
   disk_encryption_key {
@@ -97,7 +97,7 @@ resource "google_compute_resource_policy" "raft_backup" {
     }
 
     snapshot_properties {
-      labels            = var.labels
+      labels            = coalesce(var.raft_disk_snapshot_labels, var.labels)
       storage_locations = [var.raft_region]
     }
   }

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -479,6 +479,18 @@ variable "raft_extra_parameters" {
   default     = {}
 }
 
+variable "raft_disk_labels" {
+  description = "Override labels for Raft GCE PD resources. Will use `var.labels` if set to null"
+  default     = null
+  type        = map(string)
+}
+
+variable "raft_disk_snapshot_labels" {
+  description = "Override labels for Raft GCE PD snapshot resources. Will use `var.labels` if set to null"
+  default     = null
+  type        = map(string)
+}
+
 ##################################
 # Raft Data Disk Backup
 ##################################

--- a/modules/vault/versions.tf
+++ b/modules/vault/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_version = ">= 0.12.17"
 
   required_providers {
-    helm = ">= 1.0"
+    helm       = ">= 1.0"
+    kubernetes = ">= 1.11.4"
   }
 }


### PR DESCRIPTION
- In particular, GKE adds `"goog-gke-volume" : ""` labels